### PR TITLE
Add dynamic imports for slider components

### DIFF
--- a/src/components/ClientSlider.tsx
+++ b/src/components/ClientSlider.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import Slider from "react-slick";
+import dynamic from "next/dynamic";
+
+const Slider = dynamic(() => import("react-slick"), { ssr: false });
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { TestimonialData } from "../types/testimonial.types";
 import TestimonialCard from "./Testimonials/TestimonialCard";

--- a/src/components/MediaGallery.tsx
+++ b/src/components/MediaGallery.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import Slider from "react-slick";
+import dynamic from "next/dynamic";
+
+const Slider = dynamic(() => import("react-slick"), { ssr: false });
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface MediaItem {


### PR DESCRIPTION
## Summary
- lazily load `react-slick` in `ClientSlider` and `MediaGallery`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3384e010832c9ac10004cac6a224